### PR TITLE
[IMP] name first in view and more compact form

### DIFF
--- a/distribution_circuits_sale/views/time_frame_view.xml
+++ b/distribution_circuits_sale/views/time_frame_view.xml
@@ -32,13 +32,12 @@
 	                <sheet>
 	                	<group>
 		                	<group>
+		                		<field name="name"/>
 				            	<field name="delivery_date"/>
 				            	<field name="start"/>
 				            	<field name="end"/>
 			            	</group>
-			            	<group></group>
-		                	<group colspan="4">
-		                		<field name="name"/>
+		                	<group>
 		                		<field name="filter_on_products"/>
 		                		<field name="resellers_only"/>
 		                	</group>


### PR DESCRIPTION
**before** 

- date is first field so a "date" widget pops up whenever you try to edit the time frame
- `colspan=4` attribute makes a big non standard dropdown

**after**

- name as first field (quite standard)
- remove colspan and group items together