### PR TITLE
[ADD] website_sale_preset_carts: suspend cart form

### DIFF
--- a/website_sale_preset_carts/__manifest__.py
+++ b/website_sale_preset_carts/__manifest__.py
@@ -31,5 +31,7 @@
         "views/time_frame.xml",
         "views/subscription.xml",
         "views/menu.xml",
+        "templates/suspend_cart_portal.xml",
+        "templates/suspend_cart_form.xml",
     ]
 }

--- a/website_sale_preset_carts/controllers/__init__.py
+++ b/website_sale_preset_carts/controllers/__init__.py
@@ -1,1 +1,2 @@
 from . import auth_signup
+from . import suspend_cart

--- a/website_sale_preset_carts/controllers/suspend_cart.py
+++ b/website_sale_preset_carts/controllers/suspend_cart.py
@@ -1,0 +1,127 @@
+# Copyright 2020 Coop IT Easy SCRL fs
+#   Rémy Taymans <remy@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from datetime import date, datetime, timedelta
+
+from odoo import http
+from odoo.http import request
+from odoo.tools.translate import _
+
+
+class WebsiteSuspendCart(http.Controller):
+    @http.route("/cart/suspend", type="http", auth="user", website=True)
+    def cart_suspend(self, **post):
+        """Route to edit cart suspension dates."""
+        form_context = {"partner": request.env.user.partner_id}
+        data = request.params.copy()
+        errors = {}
+        if request.httprequest.method == "POST":
+            cleaned_data, errors = self.clean_and_validate_form(data=data)
+            if not errors:
+                self.process_suspend_cart_form(
+                    cleaned_data=cleaned_data, context=form_context
+                )
+                return request.redirect(
+                    request.params.get("redirect")
+                )
+        qcontext = {
+            "data": data,
+            "initial": self.suspend_cart_form_initial(context=form_context),
+            "errors": errors,
+            "redirect": request.params.get("redirect") or "/my/home",
+            "today": date.today().isoformat(),
+        }
+        return request.render(
+            "website_sale_preset_carts.suspend_cart_form", qcontext
+        )
+
+    def suspend_cart_form_initial(self, context=None):
+        """Return initial for suspend cart form."""
+        context = {} if context is None else context
+        initial = {}
+        partner = context.get("partner")
+        if partner.suspend_cart:
+            initial["date_from"] = partner.cart_suspended_from
+            initial["date_to"] = partner.cart_suspended_date
+        else:
+            initial["date_from"] = date.today().isoformat()
+            initial["date_to"] = (date.today() + timedelta(days=1)).isoformat()
+        return initial
+
+    def clean_and_validate_form(self, data):
+        """Return the cleaned data and errors."""
+        cleaned_data = {}
+        errors = {}
+        # Date from
+        field = "date_from"
+        value = data.get(field)
+        try:
+            value = self.clean_and_validate_date_from(value, data=data)
+            cleaned_data[field] = value
+        except ValueError as err:
+            errors.update({field: err})
+        # Date to
+        field = "date_to"
+        value = data.get(field)
+        try:
+            value = self.clean_and_validate_date_from(value, data=data)
+            cleaned_data[field] = value
+        except ValueError as err:
+            errors += {field: err}
+        return cleaned_data, errors
+
+    def clean_and_validate_date_from(self, value, data=None):
+        """
+        Return the cleaned value and Raise ValueError if the
+        date_from is not valid.
+        """
+        if not value:
+            raise ValueError(_("This field is required."))
+        try:
+            value_date = datetime.strptime(value, "%Y-%m-%d").date()
+        except ValueError:
+            raise ValueError(_("Wrong format for the date."))
+        if value_date <= date.today():
+            raise ValueError(_("Date can not be in the past."))
+        return value
+
+    def clean_and_validate_date_to(self, value, data=None):
+        """
+        Return the cleaned value and Raise ValueError if the
+        date_to is not valid.
+        """
+        if not value:
+            raise ValueError(_("This field is required."))
+        try:
+            value_date = datetime.strptime(value, "%Y-%m-%d").date()
+        except ValueError:
+            raise ValueError(_("Wrong format for the date."))
+        try:
+            date_from = datetime.strptime(
+                data.get("date_from"), "%Y-%m-%d"
+            ).date()
+        except ValueError:
+            date_from = date.today()
+        if value_date <= date.today():
+            raise ValueError(_("Date can not be in the past."))
+        if value_date <= date_from:
+            raise ValueError(_("End date can not be before begin date."))
+        return value
+
+    def process_suspend_cart_form(self, cleaned_data, context=None):
+        """Process subscription share form."""
+        partner = context.get("partner")
+        vals = self.res_partner_vals(
+            cleaned_data=cleaned_data, context=context
+        )
+        partner.write(vals)
+
+    def res_partner_vals(self, cleaned_data, context=None):
+        """Reutrn vals to update suspend cart value."""
+        vals = {
+            "suspend_cart": True,
+            "cart_suspended_from": cleaned_data["date_from"],
+            "cart_suspended_date": cleaned_data["date_to"],
+        }
+        return vals

--- a/website_sale_preset_carts/templates/suspend_cart_form.xml
+++ b/website_sale_preset_carts/templates/suspend_cart_form.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 Coop IT Easy SCRLfs <http://coopiteasy.be>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+
+    <template id="suspend_cart_form" name="Suspend Cart Form">
+        <t t-call="portal.portal_layout">
+            <t t-set="additional_title">Suspend Cart</t>
+            <t t-set="no_breadcrumbs" t-value="True"/>
+            <div class="row justify-content-center">
+                <div class="col-xs-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6">
+                    <h3 class="text-center mt-4">
+                        Suspend Cart
+                    </h3>
+                    <form class="oe_suspend_cart_form" role="form" method="post" t-if="not message">
+                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+
+                        <p class="alert alert-danger" role="alert" t-if="errors.get('__all__')">
+                            <t t-esc="errors.get('__all__')"/>
+                        </p>
+
+                        <div t-attf-class="form-group field-date_from">
+                            <label t-attf-for="date_from">Date From</label>
+                            <input t-attf-id="date_from"
+                                class="form-control form-control-sm"
+                                t-att-min="today"
+                                type="date"
+                                name="date_from"
+                                t-att-value="data.get('date_from', initial.get('date_from'))"
+                                required="required"
+                            />
+                        </div>
+                        <p class="alert alert-danger" t-if="'date_from' in errors" role="alert">
+                            <t t-esc="str(errors['date_from'])"/>
+                        </p>
+
+                        <div t-attf-class="form-group field-date_to">
+                            <label t-attf-for="date_to">Date To</label>
+                            <input t-attf-id="date_to"
+                                class="form-control form-control-sm"
+                                t-att-min="today"
+                                type="date"
+                                name="date_to"
+                                t-att-value="data.get('date_to', initial.get('date_to'))"
+                                required="required"
+                            />
+                        </div>
+                        <p class="alert alert-danger" t-if="'date_to' in errors" role="alert">
+                            <t t-esc="str(errors['date_to'])"/>
+                        </p>
+
+                        <p class="alert alert-danger" role="alert" t-if="errors.get('__all__')">
+                            <t t-esc="errors.get('__all__')"/>
+                        </p>
+
+                        <input type="hidden" name="redirect" t-att-value="redirect"/>
+                        <div class="text-center oe_login_buttons pt-3">
+                            <button type="submit" class="btn btn-primary btn-block">Send</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </t>
+    </template>
+
+</odoo>

--- a/website_sale_preset_carts/templates/suspend_cart_portal.xml
+++ b/website_sale_preset_carts/templates/suspend_cart_portal.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 Coop IT Easy SCRLfs <http://coopiteasy.be>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+
+    <template id="suspend_cart_portal" name="Suspend Cart Portal" inherit_id="portal.portal_layout">
+        <xpath expr="//div[hasclass('o_portal_my_details')]" position="after">
+            <div class="o_portal_suspend_cart_date">
+                <h3 class="page-header">
+                  Cart Suspended <a href="/cart/suspend" class="btn btn-default btn-xs">Change</a>
+                </h3>
+                <p t-if="user_id.partner_id.suspend_cart">
+                    <div>
+                        <span>Suspended from:</span> <span t-field="user_id.partner_id.cart_suspended_from"/>
+                    </div>
+                    <div>
+                        <span>Suspended until:</span> <span t-field="user_id.partner_id.cart_suspended_date"/>
+                    </div>
+                </p>
+                <p t-else="">
+                    You have not planned a moment to suspend your cart.
+                </p>
+            </div>
+        </xpath>
+    </template>
+
+    <template id="suspend_cart_portal_help" name="Suspend Cart Portal Help" inherit_id="suspend_cart_portal">
+        <xpath expr="//div[hasclass('o_portal_suspend_cart_date')]/h3" position="after">
+            <div class="o_portal_suspend_cart_help">
+                <p>
+                    This is help text for suspended cart portal. Change text in translation or disable the template.
+                </p>
+            </div>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This adds the ability to user to modify the suspended date for the delivery of his cart in the portal.

This is a good example of a simple form following common standard.

PR #13 should be merged before this one.

Task is [here](https://gestion.coopiteasy.be/web?debug=assets#id=3998&view_type=form&model=project.task&menu_id=338&action=479).