### PR TITLE
[ADD] website_sale_preset_cart: setting for sending sale order on timeframe open/close

### DIFF
--- a/website_sale_preset_carts/__manifest__.py
+++ b/website_sale_preset_carts/__manifest__.py
@@ -27,6 +27,7 @@
         "security/ir.model.access.csv",
         "views/auth_signup_template.xml",
         "views/preset_cart.xml",
+        "views/res_config_settings.xml",
         "views/res_partner.xml",
         "views/time_frame.xml",
         "views/subscription.xml",

--- a/website_sale_preset_carts/models/__init__.py
+++ b/website_sale_preset_carts/models/__init__.py
@@ -1,4 +1,5 @@
 from . import res_partner
 from . import preset_cart
+from . import res_config_settings
 from . import time_frame
 from . import subscription

--- a/website_sale_preset_carts/models/res_config_settings.py
+++ b/website_sale_preset_carts/models/res_config_settings.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from ast import literal_eval
+
+from odoo import api, models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    send_sale_order_on_timeframe_open = fields.Boolean(
+        string="Email when Timeframe is Opened",
+        default=True
+    )
+    send_sale_order_on_timeframe_close = fields.Boolean(
+        string="Email when Timeframe is Closed",
+        default=True
+    )
+
+    @api.model
+    def get_values(self):
+        res = super(ResConfigSettings, self).get_values()
+        select_type = self.env['ir.config_parameter'].sudo()
+        send_sale_order_on_timeframe_open = select_type.get_param('website_sale_preset_carts.send_sale_order_on_timeframe_open')
+        send_sale_order_on_timeframe_close = select_type.get_param('website_sale_preset_carts.send_sale_order_on_timeframe_close')
+        res.update(
+            {'send_sale_order_on_timeframe_open': send_sale_order_on_timeframe_open,
+             'send_sale_order_on_timeframe_close': send_sale_order_on_timeframe_close}
+        )
+        return res
+
+    @api.multi
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        select_type = self.env['ir.config_parameter'].sudo()
+        select_type.set_param('website_sale_preset_carts.send_sale_order_on_timeframe_open', self.send_sale_order_on_timeframe_open)
+        select_type.set_param('website_sale_preset_carts.send_sale_order_on_timeframe_close', self.send_sale_order_on_timeframe_close)

--- a/website_sale_preset_carts/views/res_config_settings.xml
+++ b/website_sale_preset_carts/views/res_config_settings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Coop IT Easy SCRLfs
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+  <record id="res_config_settings_view_form_website_sale_preset_carts" model="ir.ui.view">
+    <field name="name">
+      res.config.settings.view.form.website.sale.preset.carts
+    </field>
+    <field name="model">res.config.settings</field>
+    <field name="inherit_id" ref="website_sale.res_config_settings_view_form"/>
+    <field name="arch" type="xml">
+        <xpath expr="//div[@id='checkout_mail_setting']" position="before">
+            <div class="col-xs-12 col-md-6 o_setting_box" id="send_sale_order_on_timeframe_open">
+                <div class="o_setting_left_pane">
+                    <field name="send_sale_order_on_timeframe_open"/>
+                </div>
+                <div class="o_setting_right_pane">
+                    <label for="send_sale_order_on_timeframe_open"/>
+                    <div class="text-muted">
+                        Send Confirmation Email to Customer with Sale Order when the Timeframe is Opened
+                    </div>
+                </div>
+            </div>
+            <div class="col-xs-12 col-md-6 o_setting_box" id="send_sale_order_on_timeframe_close">
+                <div class="o_setting_left_pane">
+                    <field name="send_sale_order_on_timeframe_close"/>
+                </div>
+                <div class="o_setting_right_pane">
+                    <label for="send_sale_order_on_timeframe_close"/>
+                    <div class="text-muted">
+                        Send Confirmation Email to Customer with Sale Order when the Timeframe is Closed
+                    </div>
+                </div>
+            </div>
+      </xpath>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
This adds a setting in `res.config.settings` 'General Settings' under 'Website': 

> Send Confirmation Email to Customer with Sale Order when the Timeframe is Opened/Closed

It is `True` by default.

I'd like a check on the way I disabled sending on close: I used `with_context(send_email=True)` (because I couldn't alter the actual triggering of `force_quotation_send()` which happens in `odoo/addons/sale/models/sale.py`), similar to how it's done [in distribution_circuits_website_sale](https://github.com/coopiteasy/vertical-distribution-circuits/blob/11.0/distribution_circuits_website_sale/controllers/main.py#L102) as well as in the `sale_payment` and `website_sale` code. Might manipulated this context this have unwanted consequences?

Importantly, I couldn't launch the tests, so I'd like the reviewer to test or to help me test. Therefore, I also couldn't write a test yet.

