### PR TITLE
[FIX] handling the case where the is no sale order

### DIFF
--- a/distribution_circuits_website_sale/__manifest__.py
+++ b/distribution_circuits_website_sale/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'e-commerce',
     'author': "Coop IT Easy - Houssine BAKKALI <houssine@coopiteasy.be>",
     'website': 'https://coopiteasy.be',
-    'version': '11.0.2.0.0',
+    'version': '11.0.2.0.1',
     'license': 'AGPL-3',
     'depends': ['distribution_circuits_base',
                 'distribution_circuits_sale',

--- a/distribution_circuits_website_sale/controllers/main.py
+++ b/distribution_circuits_website_sale/controllers/main.py
@@ -70,7 +70,8 @@ class WebsiteSale(WebsiteSale):
                     request.redirect('/shop')
                 else:
                     order.sudo().write({'time_frame_id': time_frame.id})
-                    return {time_frame.id: time_frame.name}
+            else:
+                request.session['selected_time_frame'] = time_frame.id
         else:
             request.session['selected_time_frame'] = None
         return {0: ""}


### PR DESCRIPTION
Si la fenetre 1 est sélectionnée dans le menu déroulant, même quand je sélectionne la fenetre 2, on revient sur la 1
Investigations Houssine 
normalement dès que le panier est rempli on ne peut plus changer
par contre je pense que c'est un bug dû au changement de comportement entre la 9 et la 11
en 11 il n'y a pas de panier quand tu n'as rien mis dedans
du coup à mon avis c'est dû au if request.website.sale_get_order() qui n'a pas de else. donc rien n'est fait dans le cas où il n'y a pas de sale order en session.

https://gestion.coopiteasy.be/web#id=4477&view_type=form&model=project.task&action=479