### PR TITLE
[FIX] add call to product_id_change function after sol creation.

### DIFF
--- a/website_sale_preset_carts/__manifest__.py
+++ b/website_sale_preset_carts/__manifest__.py
@@ -6,13 +6,11 @@
 {
     "name": "Website Sale Preset Carts",
     "summary": "Allows the sale manager to preset weekly carts",
-    "version": "11.0.2.0.0",
+    "version": "11.0.2.0.1",
     "category": "Sales",
-    "website": "https://github.com/coopiteasy/vertical-distribution-circuits",
+    "website": "https://coopiteasy.be",
     "author": "Coop IT Easy SCRL fs",
     "license": "AGPL-3",
-    "application": False,
-    "installable": True,
     "depends": [
         "base",
         "distribution_circuits_base",
@@ -35,5 +33,6 @@
         "views/menu.xml",
         "templates/suspend_cart_portal.xml",
         "templates/suspend_cart_form.xml",
-    ]
+    ],
+    "installable": True
 }

--- a/website_sale_preset_carts/models/time_frame.py
+++ b/website_sale_preset_carts/models/time_frame.py
@@ -126,7 +126,8 @@ class TimeFrame(models.Model):
         })
         for line in lines:
             line['order_id'] = sale_order.id
-            self.env['sale.order.line'].create(line)
+            so_line = self.env['sale.order.line'].create(line)
+            so_line.product_id_change()
         return sale_order
 
     def compute_cart_amount(self, subscriber, lines):


### PR DESCRIPTION
In order to avoid problem relating to translation we add the call to the
product_id_change function to take into account all the context tied to
the sale order. It has also the advantage to take the price list into
account which wasn't the case in the previous code.