### PR TITLE
[11.0][FIX] time frame filter product template

### DIFF
--- a/distribution_circuits_website_sale/controllers/main.py
+++ b/distribution_circuits_website_sale/controllers/main.py
@@ -23,7 +23,7 @@ class WebsiteSale(WebsiteSale):
             time_frame = time_frame_obj.sudo().browse(tf_id)
             if time_frame.filter_on_products:
                 domain.append(
-                    ('id', 'in', time_frame.products.ids))
+                    ('id', 'in', time_frame.products.mapped('product_tmpl_id.id')))
         return domain
 
     @http.route([


### PR DESCRIPTION
Fixes the error that on databases where the `product.product` id and `product.template` id are not the same, the product selection for timeframes was wrong.