### PR TITLE
[11.0][REF] distribution_circuits_logistic: use paperformat

### DIFF
--- a/distribution_circuits_logistic/__manifest__.py
+++ b/distribution_circuits_logistic/__manifest__.py
@@ -20,6 +20,7 @@
     'data': [
         'security/ir.model.access.csv',
         'data/distribution_circuits_logistic_data.xml',
+        'data/paperformat.xml',
         'views/menu_item.xml',
         'views/stock_view.xml',
         'views/delivery_round_view.xml',

--- a/distribution_circuits_logistic/data/paperformat.xml
+++ b/distribution_circuits_logistic/data/paperformat.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="paperformat_distribution_circuits_logistic_report_standard" model="report.paperformat">
+        <field name="name">A4 Distribution Circuits Logistic Standard</field>
+        <field name="default" eval="True"/>
+        <field name="format">A4</field>
+        <field name="orientation">Portrait</field>
+        <field name="margin_top">10</field>
+        <field name="header_spacing">5</field>
+        <field name="dpi">110</field>
+    </record>
+
+    <record id="paperformat_distribution_circuits_logistic_report_top_30" model="report.paperformat">
+        <field name="name">A4 Distribution Circuits Logistic Top 30</field>
+        <field name="default" eval="True"/>
+        <field name="format">A4</field>
+        <field name="orientation">Portrait</field>
+        <field name="margin_top">30</field>
+        <field name="header_spacing">30</field>
+        <field name="dpi">110</field>
+    </record>
+
+</odoo>

--- a/distribution_circuits_logistic/report/customer_picking_consolidation_report.xml
+++ b/distribution_circuits_logistic/report/customer_picking_consolidation_report.xml
@@ -62,10 +62,6 @@
 
 	<template id="theme_customer_picking_consolidation">
 	    <t t-call="web.html_container">
-	        <t t-set="data_report_margin_top" t-value="10"/>
-	        <t t-set="data_report_header_spacing" t-value="5"/>
-	        <t t-set="data_report_dpi" t-value="110"/>
-	        
 	        <t t-foreach="docs" t-as="o">
 	            <t t-call="distribution_circuits_logistic.theme_customer_picking_consolidation_document" t-lang="o.user_id.lang"/>
 	        </t>    	    	

--- a/distribution_circuits_logistic/report/logistic_report.xml
+++ b/distribution_circuits_logistic/report/logistic_report.xml
@@ -8,6 +8,7 @@
             report_type="qweb-pdf"
             name="distribution_circuits_logistic.theme_picking_consolidation"
             file="distribution_circuits_logistic.picking_consolidation_report.xml"
+            paperformat="distribution_circuits_logistic.paperformat_distribution_circuits_logistic_report_standard"
         />
         <report 
             id="action_supplier_picking_consolidation"
@@ -16,6 +17,7 @@
             report_type="qweb-pdf"
             name="distribution_circuits_logistic.theme_supplier_picking_consolidation"
             file="distribution_circuits_logistic.supplier_picking_consolidation_report.xml"
+            paperformat="distribution_circuits_logistic.paperformat_distribution_circuits_logistic_report_standard"
         />
         <report 
             id="action_customer_picking_consolidation"
@@ -24,6 +26,7 @@
             report_type="qweb-pdf"
             name="distribution_circuits_logistic.theme_customer_picking_consolidation"
             file="distribution_circuits_logistic.customer_picking_consolidation_report.xml"
+            paperformat="distribution_circuits_logistic.paperformat_distribution_circuits_logistic_report_standard"
         />
 	</data>
 </odoo>

--- a/distribution_circuits_logistic/report/picking_consolidation_report.xml
+++ b/distribution_circuits_logistic/report/picking_consolidation_report.xml
@@ -60,10 +60,6 @@
 
 	<template id="theme_picking_consolidation">
 	    <t t-call="web.html_container">
-	        <t t-set="data_report_margin_top" t-value="10"/>
-	        <t t-set="data_report_header_spacing" t-value="5"/>
-	        <t t-set="data_report_dpi" t-value="110"/>
-	        
 	        <t t-foreach="docs" t-as="o">
 	            <t t-call="distribution_circuits_logistic.theme_picking_consolidation_document" t-lang="o.user_id.lang"/>
 	        </t>    	    	

--- a/distribution_circuits_logistic/report/supplier_picking_consolidation_report.xml
+++ b/distribution_circuits_logistic/report/supplier_picking_consolidation_report.xml
@@ -60,10 +60,6 @@
 
 	<template id="theme_supplier_picking_consolidation">
 	    <t t-call="web.html_container">
-	        <t t-set="data_report_margin_top" t-value="10"/>
-	        <t t-set="data_report_header_spacing" t-value="5"/>
-	        <t t-set="data_report_dpi" t-value="110"/>
-	        
 	        <t t-foreach="docs" t-as="o">
 	            <t t-call="distribution_circuits_logistic.theme_supplier_picking_consolidation_document" t-lang="o.user_id.lang"/>
 	        </t>    	    	


### PR DESCRIPTION
Moving the page specification from the report template to a paperformat.
- Adding two paperformats, one with the specification from the report template, one with improved specification for one client
- Removing specifications from report template
- Specifying paperformat used by reports