### PR TITLE
[11.0] [FIX] sale oder delivery point

### DIFF
--- a/distribution_circuits_sale/models/sale.py
+++ b/distribution_circuits_sale/models/sale.py
@@ -15,6 +15,12 @@ class SaleOrder(models.Model):
         string="Raliment Point",
         domain=[('is_raliment_point', '=', True)],
         store=True)
+    delivery_point = fields.Many2one(
+        compute="_compute_delivery",
+        comodel_name="res.partner",
+        string="Delivery Point",
+        domain=[('is_delivery_point', '=', True)],
+        store=True)
     enough_credit = fields.Boolean(
         compute="_compute_enough_credit",
         string="Enough credit")
@@ -24,8 +30,8 @@ class SaleOrder(models.Model):
         for order in self:
             if order.raliment_point:
                 order.partner_shipping_id = order.raliment_point
-            elif order.partner_id.delivery_point_id:
-                order.partner_shipping_id = order.delivery_point_id
+            elif order.delivery_point:
+                order.partner_shipping_id = order.delivery_point
         return super(SaleOrder, self).action_confirm()
 
     @api.multi
@@ -34,6 +40,13 @@ class SaleOrder(models.Model):
         for order in self:
             if order.partner_id.raliment_point_id:
                 order.raliment_point = order.partner_id.raliment_point_id
+
+    @api.multi
+    @api.depends('partner_id')
+    def _compute_delivery(self):
+        for order in self:
+            if order.partner_id.delivery_point_id:
+                order.delivery_point = order.partner_id.delivery_point_id
 
     @api.multi
     def _compute_enough_credit(self):


### PR DESCRIPTION
This fixes an error occurring when a sale order was confirmed with the order having a delivery point.

There were two option:
- The one taken here, adding the field `delivery_point` to the sale order
- The option of correcting the typo to 
```py
            elif order.partner_id.delivery_point_id:
                order.partner_shipping_id = order.partner_id.delivery_point_id
```

I chose the first one because it's more future-proof and symmetrical with the raliment point imo.