### PR TITLE
[FIX] distribution_circuits_sale: amount due exclude 'nothing to invo…

### DIFF
--- a/distribution_circuits_sale/models/partner.py
+++ b/distribution_circuits_sale/models/partner.py
@@ -30,7 +30,7 @@ class Partner(models.Model):
             orders = order_obj.search([
                 ('partner_id', '=', partner.id),
                 ('state', 'in', ['sent', 'sale']),
-                ('invoice_status', '!=', 'invoiced')
+                ('invoice_status', 'not in', ['invoiced', 'no'])
                 ])
 
             partner.amount_due = sum(o.amount_total for o in orders)


### PR DESCRIPTION
This fixes the computation of `amount_due`, excluding the invoices with invoice statues 'nothing to invoice', i.e. `invoice_status = 'no'`.