### PR TITLE
[ADD] d_c_[base|sale]: raliment_point_id on `sale.report`

### DIFF
--- a/distribution_circuits_base/models/res_partner.py
+++ b/distribution_circuits_base/models/res_partner.py
@@ -12,6 +12,7 @@ class ResPartner(models.Model):
     raliment_point_id = fields.Many2one(
         'res.partner',
         string="Point de Raliment",
+        store=True,
         domain=[('is_raliment_point', '=', True)])
     raliment_point_manager = fields.Many2one(
         'res.users',

--- a/distribution_circuits_sale/__init__.py
+++ b/distribution_circuits_sale/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import report

--- a/distribution_circuits_sale/__manifest__.py
+++ b/distribution_circuits_sale/__manifest__.py
@@ -26,6 +26,7 @@
     ],
     'data': [
         'security/ir.model.access.csv',
+        'report/sale_report_views.xml',
         'views/time_frame_view.xml',
         'views/sale_view.xml',
         'views/partner_view.xml',

--- a/distribution_circuits_sale/report/__init__.py
+++ b/distribution_circuits_sale/report/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_report

--- a/distribution_circuits_sale/report/sale_report.py
+++ b/distribution_circuits_sale/report/sale_report.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+
+class SaleReport(models.Model):
+    _inherit = "sale.report"
+
+    raliment_point_id = fields.Many2one('res.partner', 'Point de Raliment', readonly=True)
+    time_frame_id = fields.Many2one('time.frame', string="Time Frame", readonly=True)
+
+    def _select(self):
+        return super(SaleReport, self)._select() + ", partner.raliment_point_id as raliment_point_id, s.time_frame_id as time_frame_id"
+
+    def _group_by(self):
+        return super(SaleReport, self)._group_by() + ", partner.raliment_point_id, s.time_frame_id"

--- a/distribution_circuits_sale/report/sale_report_views.xml
+++ b/distribution_circuits_sale/report/sale_report_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_order_product_search" model="ir.ui.view">
+        <field name="name">sale.report.search</field>
+        <field name="model">sale.report</field>
+        <field name="inherit_id" ref="sale.view_order_product_search"/>
+        <field name="arch" type="xml">
+            <filter name="Sales" position="after">
+                <filter string="Time Frame" name="time_frame" domain="[('time_frame_id', '!=', 'False')]"/>
+            </filter>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
#### [Task](https://gestion.coopiteasy.be/web#id=5779&view_type=form&model=project.task)
 
According to Odoo 12 Development Essentials, in a pivot view, since "_Data aggregations are only available for database stored fields_", to have `raliment_point_id` (on `res.partner` model) available for this view, we need to first have it stored in the database, by adding the `store=True` attribute. 

Unfortunately, this alone didn't allow the field to appear in the pivot view. 

The complete solution is inspired by [`sale_stock`'s way of adding `warehouse_id` field on `sale.report` model.](https://github.com/coopiteasy/OCB/blob/11.0/addons/sale_stock/report/sale_report.py)

In `sale` module,
- `sale.report`'s _select():

```python
    def _select(self):
        select_str = """
            WITH currency_rate as (%s)
             SELECT min(l.id) as id,
                    l.product_id as product_id,
                    t.uom_id as product_uom,
                    sum(l.product_uom_qty / u.factor * u2.factor) as product_uom_qty,
                    sum(l.qty_delivered / u.factor * u2.factor) as qty_delivered,
                    sum(l.qty_invoiced / u.factor * u2.factor) as qty_invoiced,
                    sum(l.qty_to_invoice / u.factor * u2.factor) as qty_to_invoice,
                    sum(l.price_total / COALESCE(NULLIF(cr.rate, 0), 1.0)) as price_total,
                    sum(l.price_subtotal / COALESCE(NULLIF(cr.rate, 0), 1.0)) as price_subtotal,
                    sum(l.amt_to_invoice / COALESCE(NULLIF(cr.rate, 0), 1.0)) as amt_to_invoice,
                    sum(l.amt_invoiced / COALESCE(NULLIF(cr.rate, 0), 1.0)) as amt_invoiced,
                    count(*) as nbr,
                    s.name as name,
                    s.date_order as date,
                    s.confirmation_date as confirmation_date,
                    s.state as state,
                    s.partner_id as partner_id,
                    s.user_id as user_id,
                    s.company_id as company_id,
                    extract(epoch from avg(date_trunc('day',s.date_order)-date_trunc('day',s.create_date)))/(24*60*60)::decimal(16,2) as delay,
                    t.categ_id as categ_id,
                    s.pricelist_id as pricelist_id,
                    s.analytic_account_id as analytic_account_id,
                    s.team_id as team_id,
                    p.product_tmpl_id,
                    partner.country_id as country_id,
                    partner.commercial_partner_id as commercial_partner_id,
                    sum(p.weight * l.product_uom_qty / u.factor * u2.factor) as weight,
                    sum(p.volume * l.product_uom_qty / u.factor * u2.factor) as volume
        """ % self.env['res.currency']._select_companies_rates()
        return select_str
```

- `_group_by()`: 
```python
    def _group_by(self):
        group_by_str = """
            GROUP BY l.product_id,
                    l.order_id,
                    t.uom_id,
                    t.categ_id,
                    s.name,
                    s.date_order,
                    s.confirmation_date,
                    s.partner_id,
                    s.user_id,
                    s.state,
                    s.company_id,
                    s.pricelist_id,
                    s.analytic_account_id,
                    s.team_id,
                    p.product_tmpl_id,
                    partner.country_id,
                    partner.commercial_partner_id
        """
        return group_by_str
```